### PR TITLE
Normalize policy JSON before diffing

### DIFF
--- a/astro/cli/astro/cmd/cmds.go
+++ b/astro/cli/astro/cmd/cmds.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	detach            bool
+	disablePolicyDiff bool
 	moduleNamesString string
 )
 
@@ -60,7 +61,7 @@ var applyCmd = &cobra.Command{
 			return fmt.Errorf("error running Terraform: %v", err)
 		}
 
-		err = printExecStatus(status, results)
+		err = printExecStatus(status, results, disablePolicyDiff)
 		if err != nil {
 			return fmt.Errorf("Done; there were errors; some modules may not have been applied")
 		}
@@ -102,7 +103,7 @@ var planCmd = &cobra.Command{
 			return fmt.Errorf("error running Terraform: %v", err)
 		}
 
-		err = printExecStatus(status, results)
+		err = printExecStatus(status, results, disablePolicyDiff)
 		if err != nil {
 			return errors.New("Done; there were errors")
 		}
@@ -138,5 +139,6 @@ func init() {
 
 	planCmd.PersistentFlags().BoolVar(&detach, "detach", false, "disconnect remote state before planning")
 	planCmd.PersistentFlags().StringVar(&moduleNamesString, "modules", "", "list of modules to plan")
+	planCmd.PersistentFlags().BoolVar(&disablePolicyDiff, "no-policy-diff", false, "do not show policy changes as diffs")
 	rootCmd.AddCommand(planCmd)
 }

--- a/astro/cli/astro/cmd/display.go
+++ b/astro/cli/astro/cmd/display.go
@@ -32,7 +32,7 @@ import (
 
 // printExecStatus takes channels for status updates and exec results
 // and prints them on screen as they arrive.
-func printExecStatus(status <-chan string, results <-chan *astro.Result) (errors error) {
+func printExecStatus(status <-chan string, results <-chan *astro.Result, disablePolicyDiff bool) (errors error) {
 	// Print status updates to stdout as they arrive
 	if status != nil {
 		go func() {
@@ -97,7 +97,7 @@ func printExecStatus(status <-chan string, results <-chan *astro.Result) (errors
 		// If this was a plan, print the plan
 		if planResult != nil && planResult.HasChanges() {
 			planOutput := planResult.Changes()
-			if terraform.CanDisplayReadableTerraformPolicyChanges() {
+			if !disablePolicyDiff && terraform.CanDisplayReadableTerraformPolicyChanges() {
 				var err error
 				planOutput, err = terraform.ReadableTerraformPolicyChanges(planOutput)
 				if err != nil {

--- a/astro/terraform/policy_diff.go
+++ b/astro/terraform/policy_diff.go
@@ -40,8 +40,8 @@ var (
 	}
 	newline = []byte("\n")
 	// regular expressions that matches a policy add/change in a Terraform diff.
-	terraformPolicyAddLine    = regexp.MustCompile(`\s*policy:\s+"(.*)"`)
-	terraformPolicyChangeLine = regexp.MustCompile(`\s*policy:\s+"(.*)" => "(.*)"`)
+	terraformPolicyAddLine    = regexp.MustCompile(`^(.*\b(?:assume_role_policy|policy):\s+)"(.*)"`)
+	terraformPolicyChangeLine = regexp.MustCompile(`^(.*\b(?:assume_role_policy|policy):\s+)"(.*)" => "(.*)"`)
 )
 
 func init() {
@@ -138,10 +138,13 @@ func readableTerraformPolicyChangesWithDiffer(differ, terraformChanges string) (
 		// Get a readable diff from the policy change
 		var difftext []byte
 		var err error
+		var fieldName string
 		if changeGroups != nil {
-			difftext, err = terraformPolicyChangeToDiff(differ, changeGroups[1], changeGroups[2])
+			fieldName = changeGroups[1]
+			difftext, err = terraformPolicyChangeToDiff(differ, changeGroups[2], changeGroups[3])
 		} else {
-			difftext, err = terraformPolicyChangeToDiff(differ, "", addGroups[1])
+			fieldName = addGroups[1]
+			difftext, err = terraformPolicyChangeToDiff(differ, "", addGroups[2])
 		}
 		if err != nil {
 			errs = multierror.Append(errs, err)
@@ -151,9 +154,15 @@ func readableTerraformPolicyChangesWithDiffer(differ, terraformChanges string) (
 		}
 
 		// Output a readable diff
-		result += "\n"
-		result += string(tail(difftext, 2, true))
-		result += "\n"
+		if len(difftext) > 0 {
+			result += fieldName
+			result += "\n"
+			result += string(tail(difftext, 2, true))
+			result += "\n"
+		} else {
+			result += fieldName
+			result += "<no changes after normalization>\n"
+		}
 	}
 
 	return result, errs

--- a/astro/terraform/policy_diff.go
+++ b/astro/terraform/policy_diff.go
@@ -103,12 +103,16 @@ func jsonPretty(in []byte) ([]byte, error) {
 	if len(in) == 0 {
 		return in, nil
 	}
-	var out bytes.Buffer
-	err := json.Indent(&out, in, "", "  ")
+	var unmarshalled interface{}
+	err := json.Unmarshal(in, &unmarshalled)
 	if err != nil {
 		return nil, err
 	}
-	return out.Bytes(), nil
+	out, err := json.MarshalIndent(unmarshalled, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // CanDisplayReadableTerraformPolicyChanges is true when the prerequisites for

--- a/astro/terraform/policy_diff_test.go
+++ b/astro/terraform/policy_diff_test.go
@@ -61,23 +61,18 @@ Path: mgmt.plan
 
 ~ module.policies.aws_iam_policy.billing
 
-@@ -2,14 +2,13 @@
-   "Version": "2012-10-17",
-   "Statement": [
-     {
-+      "Sid": "",
-       "Effect": "Allow",
-       "Action": [
-         "budgets:*",
+@@ -6,9 +6,8 @@
          "aws-portal:View*"
        ],
+       "Effect": "Allow",
 -      "Resource": [
 -        "*"
 -      ]
-+      "Resource": "*"
++      "Resource": "*",
++      "Sid": ""
      }
-   ]
- }
+   ],
+   "Version": "2012-10-17"
 
 
 Plan: 0 to add, 1 to change, 0 to destroy.
@@ -121,22 +116,51 @@ Path: mgmt.plan
 
 @@ -0,0 +1,14 @@
 +{
-+  "Version": "2012-10-17",
 +  "Statement": [
 +    {
-+      "Sid": "",
-+      "Effect": "Allow",
 +      "Action": [
 +        "budgets:*",
 +        "aws-portal:View*"
 +      ],
-+      "Resource": "*"
++      "Effect": "Allow",
++      "Resource": "*",
++      "Sid": ""
 +    }
-+  ]
++  ],
++  "Version": "2012-10-17"
 +}
 
 
 Plan: 0 to add, 1 to change, 0 to destroy.
+`
+
+	diffedPolicy, err := readableTerraformPolicyChangesWithDiffer(testDifferPath, inputText)
+
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(expectedOutput), strings.TrimSpace(diffedPolicy))
+}
+
+func TestJSONNormalization(t *testing.T) {
+	if testDifferPath == "" {
+		t.Skip("skipping test since there is no diff program")
+	}
+
+	inputText := `
+~ module.policies.aws_iam_policy.billing
+policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n     ],\n \"Sid\": \"a\",\n     \"Resource\": \"*\"\n    }\n  ]\n}" => "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"b\",\n      \"Resource\": \"*\"\n    ,\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n      ]}\n  ]\n}"
+`
+	expectedOutput := `
+~ module.policies.aws_iam_policy.billing
+
+@@ -7,7 +7,7 @@
+       ],
+       "Effect": "Allow",
+       "Resource": "*",
+-      "Sid": "a"
++      "Sid": "b"
+     }
+   ],
+   "Version": "2012-10-17"
 `
 
 	diffedPolicy, err := readableTerraformPolicyChangesWithDiffer(testDifferPath, inputText)

--- a/astro/terraform/policy_diff_test.go
+++ b/astro/terraform/policy_diff_test.go
@@ -46,7 +46,7 @@ plan.
 Path: mgmt.plan
 
 ~ module.policies.aws_iam_policy.billing
-policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n      ],\n      \"Resource\": [\n        \"*\"\n      ]\n    }\n  ]\n}" => "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n      ],\n      \"Resource\": \"*\"\n    }\n  ]\n}"
+  policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n      ],\n      \"Resource\": [\n        \"*\"\n      ]\n    }\n  ]\n}" => "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n      ],\n      \"Resource\": \"*\"\n    }\n  ]\n}"
 
 Plan: 0 to add, 1 to change, 0 to destroy.
 `
@@ -60,7 +60,7 @@ plan.
 Path: mgmt.plan
 
 ~ module.policies.aws_iam_policy.billing
-
+  policy: 
 @@ -6,9 +6,8 @@
          "aws-portal:View*"
        ],
@@ -99,7 +99,7 @@ plan.
 Path: mgmt.plan
 
 ~ module.policies.aws_iam_policy.billing
-policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n      ],\n      \"Resource\": \"*\"\n    }\n  ]\n}"
+  policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"\",\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n      ],\n      \"Resource\": \"*\"\n    }\n  ]\n}"
 
 Plan: 0 to add, 1 to change, 0 to destroy.
 `
@@ -113,7 +113,7 @@ plan.
 Path: mgmt.plan
 
 ~ module.policies.aws_iam_policy.billing
-
+  policy: 
 @@ -0,0 +1,14 @@
 +{
 +  "Statement": [
@@ -147,11 +147,11 @@ func TestJSONNormalization(t *testing.T) {
 
 	inputText := `
 ~ module.policies.aws_iam_policy.billing
-policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n     ],\n \"Sid\": \"a\",\n     \"Resource\": \"*\"\n    }\n  ]\n}" => "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"b\",\n      \"Resource\": \"*\"\n    ,\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n      ]}\n  ]\n}"
+  policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n     ],\n \"Sid\": \"a\",\n     \"Resource\": \"*\"\n    }\n  ]\n}" => "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Sid\": \"b\",\n      \"Resource\": \"*\"\n    ,\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n      ]}\n  ]\n}"
 `
 	expectedOutput := `
 ~ module.policies.aws_iam_policy.billing
-
+  policy: 
 @@ -7,7 +7,7 @@
        ],
        "Effect": "Allow",
@@ -161,6 +161,26 @@ policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"E
      }
    ],
    "Version": "2012-10-17"
+`
+
+	diffedPolicy, err := readableTerraformPolicyChangesWithDiffer(testDifferPath, inputText)
+
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(expectedOutput), strings.TrimSpace(diffedPolicy))
+}
+
+func TestEmptyDiff(t *testing.T) {
+	if testDifferPath == "" {
+		t.Skip("skipping test since there is no diff program")
+	}
+
+	inputText := `
+~ module.policies.aws_iam_policy.billing
+  policy: "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n     ],\n \"Sid\": \"a\",\n     \"Resource\": \"*\"\n    }\n  ]\n}" => "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Action\": [\n        \"budgets:*\",\n        \"aws-portal:View*\"\n     ],\n \"Sid\": \"a\",\n     \"Resource\": \"*\"\n    }\n  ]\n}"
+`
+	expectedOutput := `
+~ module.policies.aws_iam_policy.billing
+  policy: <no changes after normalization>
 `
 
 	diffedPolicy, err := readableTerraformPolicyChangesWithDiffer(testDifferPath, inputText)


### PR DESCRIPTION
Currently, Astro uses Indent(), which only changes whitespace:
Unmarshal+Marshal is necessary for keys to be sorted.

To avoid confusion, the case when old and new policies are the same
after normalization still shows the field as modified with an explanatory
message, and there is a command-line switch to disable policy diffing.
