### PR TITLE
Fix "pflag: help requested" on --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# astro changelog
+
+## 0.4.2 (December 24, 2018)
+
+* Fixed `--help` displaying "pflag: help requested"
+* Add `version` command
+* Deprecate `dep` in favour of vgo (minimum supported Go version is now 1.11.x)
+* Publish binaries to Github
+
 ## 0.4.1 (October 3, 2018)
 
 * Output policy changes in unified diff format (#2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 # astro changelog
 
-## 0.4.2 (December 24, 2018)
+## 0.4.2 (UNRELEASED, 2018)
 
-* Fixed `--help` displaying "pflag: help requested"
-* Add `version` command
-* Deprecate `dep` in favour of vgo (minimum supported Go version is now 1.11.x)
-* Publish binaries to Github
+* Fixed `--help` displaying "pflag: help requested" (#1)
 
 ## 0.4.1 (October 3, 2018)
 

--- a/astro/cli/astro/cmd/cmd_test.go
+++ b/astro/cli/astro/cmd/cmd_test.go
@@ -181,6 +181,12 @@ func getSessionDirs(sessionBaseDir string) ([]string, error) {
 	return sessionDirs, nil
 }
 
+func TestHelpWorks(t *testing.T) {
+	result := runTest(t, []string{"--help"}, "", terraformVersionsToTest[len(terraformVersionsToTest)-1])
+	assert.Contains(t, "A tool for managing multiple Terraform modules", result.Stdout.String())
+	assert.NoError(t, result.Err)
+}
+
 func TestProjectApplyChangesSuccess(t *testing.T) {
 	for _, version := range terraformVersionsToTest {
 		t.Run(version, func(t *testing.T) {

--- a/astro/cli/astro/cmd/main.go
+++ b/astro/cli/astro/cmd/main.go
@@ -55,9 +55,9 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() error {
-	if err := initUserFlagsFromConfig(); err != nil {
-		return err
-	}
+	// Best effort to parse flags from config files for now. TODO: we need to
+	// deal with errors here.
+	initUserFlagsFromConfig()
 	return rootCmd.Execute()
 }
 


### PR DESCRIPTION
When running `--help` without arguments, one previously got the error:

```
pflag: help requested
```

This is due to the way we are attempting to add user flags from the astro
config.

As a quick fix, we'll ignore the errors for now. A later PR will refactor the
way user flags work.
