### PR TITLE
Add version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@
   `astro.NewProject(conf)` should be changed to:
   `astro.NewProject(astro.WithConfig(conf))`
 
-
 ## 0.4.1 (October 3, 2018)
 
 * Output policy changes in unified diff format (#2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # astro changelog
 
-## 0.5.0 (UNRELEASED, 2018)
+## 0.5.0 (UNRELEASED, 2019)
 
+* Add `version` command
+* Propagate SIGINT and SIGTERM to terraform processes (#49)
+* Support detach flag with terraform 0.12 (#45)
+* Fix plan output for terraform 0.12 (#41)
+* Fix bug in initialization of allowed values (#43)
+* Don't pass varialbes to modules that don't delcare them (#40)
 * Adopt options pattern for `astro.NewProject` constructor (#26)
 * Refactor and improve integration tests to invoke them directly using cli
   rather than `os.exec` (#26)
@@ -33,6 +39,7 @@
 
   `astro.NewProject(conf)` should be changed to:
   `astro.NewProject(astro.WithConfig(conf))`
+
 
 ## 0.4.1 (October 3, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,7 @@
 
 ## 0.5.0 (UNRELEASED, 2019)
 
-* Add `version` command
-* Propagate SIGINT and SIGTERM to terraform processes (#49)
-* Support detach flag with terraform 0.12 (#45)
-* Fix plan output for terraform 0.12 (#41)
-* Fix bug in initialization of allowed values (#43)
-* Don't pass varialbes to modules that don't delcare them (#40)
+* Add `version` command (#12)
 * Adopt options pattern for `astro.NewProject` constructor (#26)
 * Refactor and improve integration tests to invoke them directly using cli
   rather than `os.exec` (#26)

--- a/astro/cli/astro/cmd/cmd.go
+++ b/astro/cli/astro/cmd/cmd.go
@@ -63,9 +63,10 @@ type AstroCLI struct {
 	}
 
 	commands struct {
-		root  *cobra.Command
-		plan  *cobra.Command
-		apply *cobra.Command
+		root    *cobra.Command
+		plan    *cobra.Command
+		apply   *cobra.Command
+		version *cobra.Command
 	}
 }
 
@@ -85,10 +86,12 @@ func NewAstroCLI(opts ...Option) (*AstroCLI, error) {
 	cli.createRootCommand()
 	cli.createPlanCmd()
 	cli.createApplyCmd()
+	cli.createVersionCmd()
 
 	cli.commands.root.AddCommand(
 		cli.commands.plan,
 		cli.commands.apply,
+		cli.commands.version,
 	)
 
 	// Set trace. Note, this will turn tracing on for all instances of astro

--- a/astro/cli/astro/cmd/cmd.go
+++ b/astro/cli/astro/cmd/cmd.go
@@ -162,11 +162,10 @@ func (cli *AstroCLI) configureDynamicUserFlags() {
 
 func (cli *AstroCLI) createRootCommand() {
 	rootCmd := &cobra.Command{
-		Use:               "astro",
-		Short:             "A tool for managing multiple Terraform modules.",
-		SilenceUsage:      true,
-		SilenceErrors:     true,
-		PersistentPreRunE: cli.preRun,
+		Use:           "astro",
+		Short:         "A tool for managing multiple Terraform modules.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	rootCmd.PersistentFlags().BoolVarP(&cli.flags.verbose, "verbose", "v", false, "verbose output")
@@ -181,6 +180,7 @@ func (cli *AstroCLI) createApplyCmd() {
 		Use:                   "apply [flags] [-- [Terraform argument]...]",
 		DisableFlagsInUseLine: true,
 		Short:                 "Run Terraform apply on all modules",
+		PersistentPreRunE:     cli.preRun,
 		RunE:                  cli.runApply,
 	}
 
@@ -194,6 +194,7 @@ func (cli *AstroCLI) createPlanCmd() {
 		Use:                   "plan [flags] [-- [Terraform argument]...]",
 		DisableFlagsInUseLine: true,
 		Short:                 "Generate execution plans for modules",
+		PersistentPreRunE:     cli.preRun,
 		RunE:                  cli.runPlan,
 	}
 
@@ -206,6 +207,9 @@ func (cli *AstroCLI) createPlanCmd() {
 func (cli *AstroCLI) preRun(cmd *cobra.Command, args []string) error {
 	logger.Trace.Println("cli: in preRun")
 
+	if cli.config == nil {
+		return fmt.Errorf("unable to find config file")
+	}
 	// Load astro from config
 	project, err := astro.NewProject(astro.WithConfig(*cli.config))
 	if err != nil {

--- a/astro/cli/astro/cmd/version.go
+++ b/astro/cli/astro/cmd/version.go
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package cmd contains the source for the `astro` command line tool
+// that operators use to interact with the project.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// When a release happens, the value of this variable will be overwritten
+	// by the linker to match the release version.
+	version = "dev"
+	commit  = ""
+	date    = ""
+)
+
+func (cli *AstroCLI) createVersionCmd() {
+	versionCmd := &cobra.Command{
+		Use:                   "version",
+		DisableFlagsInUseLine: true,
+		Short:                 "Print astro version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			versionString := []string{
+				"astro version",
+				version,
+			}
+
+			if commit != "" {
+				versionString = append(versionString, fmt.Sprintf("(%s)", commit))
+			}
+
+			if date != "" {
+				versionString = append(versionString, fmt.Sprintf("built %s", date))
+			}
+
+			println(strings.Join(versionString, " "))
+
+			return nil
+		},
+	}
+	cli.commands.version = versionCmd
+}

--- a/astro/cli/astro/cmd/version.go
+++ b/astro/cli/astro/cmd/version.go
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018 Uber Technologies, Inc.
+ *  Copyright (c) 2019 Uber Technologies, Inc.
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/astro/cli/astro/cmd/version.go
+++ b/astro/cli/astro/cmd/version.go
@@ -53,7 +53,7 @@ func (cli *AstroCLI) createVersionCmd() {
 				versionString = append(versionString, fmt.Sprintf("built %s", date))
 			}
 
-			println(strings.Join(versionString, " "))
+			fmt.Fprintln(cli.stdout, strings.Join(versionString, " "))
 
 			return nil
 		},

--- a/astro/tests/integration_test.go
+++ b/astro/tests/integration_test.go
@@ -229,9 +229,7 @@ func TestProjectPlanDetachSuccess(t *testing.T) {
 
 func TestVersionDev(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "astro-tests")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	result := RunTest(t, []string{"version"}, "/tmp/astro-tests", "")
 	assert.Equal(t, "", result.Stderr.String())
@@ -241,9 +239,7 @@ func TestVersionDev(t *testing.T) {
 
 func TestVersionWithLdflags(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "astro-tests")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	stdoutBytes := &bytes.Buffer{}
@@ -272,11 +268,19 @@ func TestVersionWithLdflags(t *testing.T) {
 
 func TestPlanErorrsWithoutConfig(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "astro-tests")
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	result := RunTest(t, []string{"plan"}, "/tmp/astro-tests", "")
+	assert.Equal(t, "unable to find config file\n", result.Stderr.String())
+	assert.Equal(t, "", result.Stdout.String())
+	assert.Equal(t, 1, result.ExitCode)
+}
+
+func TestApplyErorrsWithoutConfig(t *testing.T) {
+	dir, err := ioutil.TempDir("/tmp", "astro-tests")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	result := RunTest(t, []string{"apply"}, "/tmp/astro-tests", "")
 	assert.Equal(t, "unable to find config file\n", result.Stderr.String())
 	assert.Equal(t, "", result.Stdout.String())
 	assert.Equal(t, 1, result.ExitCode)

--- a/astro/tests/integration_test.go
+++ b/astro/tests/integration_test.go
@@ -71,14 +71,13 @@ func stringVersionMatches(v string, versionConstraint string) bool {
 }
 
 // compiles the astro binary and returns the path to it.
-func compileAstro(dir string, ldflags []string) (string, error) {
+func compileAstro(dir string, buildFlags []string) (string, error) {
 	astroPath := filepath.Join(dir, "astro")
 	packageName := "github.com/uber/astro/astro/cli/astro"
 	compileArgs := []string{"build"}
-	if len(ldflags) > 0 {
-		compileArgs = append(compileArgs, "-ldflags")
-		for _, ldflag := range ldflags {
-			compileArgs = append(compileArgs, ldflag)
+	if len(buildFlags) > 0 {
+		for _, flag := range buildFlags {
+			compileArgs = append(compileArgs, flag)
 		}
 	}
 	compileArgs = append(compileArgs, "-o", astroPath, packageName)
@@ -251,6 +250,7 @@ func TestVersionWithLdflags(t *testing.T) {
 	stderrBytes := &bytes.Buffer{}
 
 	astroBinary, err := compileAstro(dir, []string{
+		"-ldflags",
 		"-X github.com/uber/astro/astro/cli/astro/cmd.version=1.2.3 " +
 			"-X github.com/uber/astro/astro/cli/astro/cmd.commit=ab123 " +
 			"-X github.com/uber/astro/astro/cli/astro/cmd.date=2019-01-01T10:00:00",

--- a/astro/tests/integration_test.go
+++ b/astro/tests/integration_test.go
@@ -229,8 +229,8 @@ func TestProjectPlanDetachSuccess(t *testing.T) {
 
 func TestVersionDev(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "astro-tests")
-	require.NoError(t, err)
 	defer os.RemoveAll(dir)
+	require.NoError(t, err)
 	result := RunTest(t, []string{"version"}, "/tmp/astro-tests", "")
 	assert.Equal(t, "", result.Stderr.String())
 	assert.Equal(t, "astro version dev\n", result.Stdout.String())
@@ -239,8 +239,8 @@ func TestVersionDev(t *testing.T) {
 
 func TestVersionWithLdflags(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "astro-tests")
-	require.NoError(t, err)
 	defer os.RemoveAll(dir)
+	require.NoError(t, err)
 
 	stdoutBytes := &bytes.Buffer{}
 	stderrBytes := &bytes.Buffer{}
@@ -266,22 +266,17 @@ func TestVersionWithLdflags(t *testing.T) {
 	assert.Equal(t, "astro version 1.2.3 (ab123) built 2019-01-01T10:00:00\n", stdoutBytes.String())
 }
 
-func TestPlanErorrsWithoutConfig(t *testing.T) {
+func TestAstroErrorsWithoutConfig(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "astro-tests")
-	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	result := RunTest(t, []string{"plan"}, "/tmp/astro-tests", "")
-	assert.Equal(t, "unable to find config file\n", result.Stderr.String())
-	assert.Equal(t, "", result.Stdout.String())
-	assert.Equal(t, 1, result.ExitCode)
-}
+	require.NoError(t, err)
 
-func TestApplyErorrsWithoutConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "astro-tests")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	result := RunTest(t, []string{"apply"}, "/tmp/astro-tests", "")
-	assert.Equal(t, "unable to find config file\n", result.Stderr.String())
-	assert.Equal(t, "", result.Stdout.String())
-	assert.Equal(t, 1, result.ExitCode)
+	commands := []string{"plan", "apply"}
+
+	for _, cmd := range commands {
+		result := RunTest(t, []string{cmd}, "/tmp/astro-tests", "")
+		assert.Equal(t, "unable to find config file\n", result.Stderr.String())
+		assert.Equal(t, "", result.Stdout.String())
+		assert.Equal(t, 1, result.ExitCode)
+	}
 }

--- a/astro/tests/integration_test.go
+++ b/astro/tests/integration_test.go
@@ -71,10 +71,18 @@ func stringVersionMatches(v string, versionConstraint string) bool {
 }
 
 // compiles the astro binary and returns the path to it.
-func compileAstro(dir string) (string, error) {
+func compileAstro(dir string, ldflags []string) (string, error) {
 	astroPath := filepath.Join(dir, "astro")
 	packageName := "github.com/uber/astro/astro/cli/astro"
-	out, err := exec.Command("go", "build", "-o", astroPath, packageName).CombinedOutput()
+	compileArgs := []string{"build"}
+	if len(ldflags) > 0 {
+		compileArgs = append(compileArgs, "-ldflags")
+		for _, ldflag := range ldflags {
+			compileArgs = append(compileArgs, ldflag)
+		}
+	}
+	compileArgs = append(compileArgs, "-o", astroPath, packageName)
+	out, err := exec.Command("go", compileArgs...).CombinedOutput()
 	if err != nil {
 		return "", errors.New(string(out))
 	}
@@ -95,7 +103,7 @@ func TestPlanInterrupted(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 	require.NoError(t, err)
 
-	astroBinary, err := compileAstro(tmpdir)
+	astroBinary, err := compileAstro(tmpdir, []string{})
 	require.NoError(t, err)
 	command := exec.Command(astroBinary, "plan")
 
@@ -218,4 +226,58 @@ func TestProjectPlanDetachSuccess(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestVersionDev(t *testing.T) {
+	dir, err := ioutil.TempDir("/tmp", "astro-tests")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+	result := RunTest(t, []string{"version"}, "/tmp/astro-tests", "")
+	assert.Equal(t, "", result.Stderr.String())
+	assert.Equal(t, "astro version dev\n", result.Stdout.String())
+	assert.Equal(t, 0, result.ExitCode)
+}
+
+func TestVersionWithLdflags(t *testing.T) {
+	dir, err := ioutil.TempDir("/tmp", "astro-tests")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	stdoutBytes := &bytes.Buffer{}
+	stderrBytes := &bytes.Buffer{}
+
+	astroBinary, err := compileAstro(dir, []string{
+		"-X github.com/uber/astro/astro/cli/astro/cmd.version=1.2.3 " +
+			"-X github.com/uber/astro/astro/cli/astro/cmd.commit=ab123 " +
+			"-X github.com/uber/astro/astro/cli/astro/cmd.date=2019-01-01T10:00:00",
+	})
+	require.NoError(t, err)
+	command := exec.Command(astroBinary, "version")
+	command.Dir = dir
+
+	command.Stdout = stdoutBytes
+	command.Stderr = stderrBytes
+
+	err = command.Run()
+
+	require.NoError(t, err)
+
+	assert.Equal(t, "", stderrBytes.String())
+	assert.Equal(t, "astro version 1.2.3 (ab123) built 2019-01-01T10:00:00\n", stdoutBytes.String())
+}
+
+func TestPlanErorrsWithoutConfig(t *testing.T) {
+	dir, err := ioutil.TempDir("/tmp", "astro-tests")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+	result := RunTest(t, []string{"plan"}, "/tmp/astro-tests", "")
+	assert.Equal(t, "unable to find config file\n", result.Stderr.String())
+	assert.Equal(t, "", result.Stdout.String())
+	assert.Equal(t, 1, result.ExitCode)
 }


### PR DESCRIPTION
`astro version` will print the version of astro at the command line.
Version information will be set using ldflags at release time. For more
information, see:
https://stackoverflow.com/questions/11354518/golang-application-auto-build-versioning

Automated releases will be implemented in a separate PR (#14).