### PR TITLE
Add Travis, linter, commit hooks and fix races

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 before_install:
 - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 cache:
+- /home/travis/.tvm
 - vendor
 go:
  - "1.11.x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: go
 before_install:
 - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 cache:
-- /home/travis/.tvm
-- vendor
+  directories:
+    - /home/travis/.tvm
+    - vendor
 go:
  - "1.11.x"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+before_install:
+- curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+cache:
+- vendor
+go:
+ - "1.11.x"
+install:
+- make vendor
+script:
+- make lint
+- make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add Travis configuration, `make lint` and git precommit hook
 * Fix issue with `make test` always returning true even when tests fail
+* Fix a race condition that could cause failures due to astro downloading the
+  same version of Terraform twice
 
 ## 0.4.1 (October 3, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 0.4.2 (UNRELEASED, 2018)
 
 * Add Travis configuration, `make lint` and git precommit hook
+* Fix issue with make not recompiling when source files changed
 * Fix issue with `make test` always returning true even when tests fail
-* Fix a race condition that could cause failures due to astro downloading the
+* Fix race condition that could cause failures due to astro downloading the
   same version of Terraform twice
 
 ## 0.4.1 (October 3, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# astro changelog
+
+## 0.4.2 (UNRELEASED, 2018)
+
+* Add Travis configuration, `make lint` and git precommit hook
+* Fix issue with `make test` always returning true even when tests fail
+
 ## 0.4.1 (October 3, 2018)
 
 * Output policy changes in unified diff format (#2)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -o pipefail
 
-export GO111MODULE=on
+SRC = $(shell find . -name '*.go')
 
 define PRE_COMMIT_HOOK
 #!/bin/sh -xe
@@ -24,10 +24,10 @@ export PRE_COMMIT_HOOK
 bin:
 	mkdir -p bin
 
-bin/astro: bin vendor
+bin/astro: bin vendor $(SRC)
 	go build -o bin/astro github.com/uber/astro/astro/cli/astro
 
-bin/tvm: bin vendor
+bin/tvm: bin vendor $(SRC)
 	go build -o bin/tvm github.com/uber/astro/astro/tvm/cli/tvm
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -53,5 +53,6 @@ test: vendor
 	go test -timeout 1m -coverprofile=.coverage.out ./... \
 		|grep -v -E '^\?'
 
+.PHONY: vendor
 vendor:
 	dep ensure

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = /bin/bash -o pipefail
+
 export GO111MODULE=on
 
 define PRE_COMMIT_HOOK

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,11 @@ install:
 
 .PHONY: lint
 lint:
-	@f="$$(find . -name '*.go' ! -path './vendor/*' | xargs grep -L 'Licensed under the Apache License')" || { \
+	@f="$$(find . -name '*.go' ! -path './vendor/*' | xargs grep -L 'Licensed under the Apache License')"; \
+	if [ ! -z "$$f" ]; then \
 		echo "ERROR: Files missing license header:"$$'\n'"$$f" >&2; \
 		exit 1; \
-	};
+	fi;
 
 .PHONY: test
 test: vendor

--- a/astro/cli/astro/cmd/cmd_test.go
+++ b/astro/cli/astro/cmd/cmd_test.go
@@ -90,7 +90,10 @@ func TestMain(m *testing.M) {
 	// Download Terraform versions first so that multiple tests don't
 	// try to do it in parallel.
 	for _, version := range terraformVersionsToTest {
-		terraformVersionRepo.Get(version)
+		if _, err := terraformVersionRepo.Get(version); err != nil {
+			fmt.Fprint(os.Stderr, err)
+			os.Exit(1)
+		}
 	}
 
 	os.Exit(m.Run())

--- a/astro/cli/astro/cmd/fixtures/flags/merge_values.yaml
+++ b/astro/cli/astro/cmd/fixtures/flags/merge_values.yaml
@@ -1,5 +1,8 @@
 ---
 
+terraform:
+  version: 0.11.7
+
 modules:
   - name: foo_mgmt
     path: .

--- a/astro/cli/astro/cmd/fixtures/flags/no_variables.yaml
+++ b/astro/cli/astro/cmd/fixtures/flags/no_variables.yaml
@@ -1,5 +1,8 @@
 ---
 
+terraform:
+  version: 0.11.7
+
 modules:
   - name: foo
     path: .

--- a/astro/cli/astro/cmd/fixtures/flags/simple_variables.yaml
+++ b/astro/cli/astro/cmd/fixtures/flags/simple_variables.yaml
@@ -1,5 +1,8 @@
 ---
 
+terraform:
+  version: 0.11.7
+
 modules:
   - name: foo
     path: .

--- a/astro/tvm/versionrepo.go
+++ b/astro/tvm/versionrepo.go
@@ -161,8 +161,8 @@ func (r *VersionRepo) getLock(version string) *sync.Mutex {
 func (r *VersionRepo) Get(version string) (string, error) {
 	lock := r.getLock(version)
 
-	// Lock() here will block if another thread is currently downloading
-	// Terraform.
+	// Lock() here will block and wait if another thread is currently
+	// downloading Terraform.
 	lock.Lock()
 	defer lock.Unlock()
 


### PR DESCRIPTION
Adds Travis configuration, a `make lint` and precommit hook for linting
locally.

This also fixes issues in the Makefile where `make test` was returning true
even when tests failed (due to shell pipe in Makefile) and where binaries
weren't rebuilt when source files changed.

Finally, this also fixes some race conditions that were showing up as flakey
tests. Namely, fixed a race in downloading of the Terraform binary and also
when creating download directories.

* Fixes #16
* Fixes #17