### PR TITLE
Rework of CLI flag remapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.2 (UNRELEASED, 2018)
 
 * Add Travis configuration, `make lint` and git precommit hook
+* Fix `--help` displaying "pflag: help requested"
 * Fix issue with make not recompiling when source files changed
 * Fix issue with `make test` always returning true even when tests fail
 * Fix race condition that could cause failures due to astro downloading the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.4.2 (UNRELEASED, 2018)
 
 * Add Travis configuration, `make lint` and git precommit hook
-* Fix `--help` displaying "pflag: help requested"
+* Fix `--help` displaying "pflag: help requested" (#1)
 * Fix issue with make not recompiling when source files changed
 * Fix issue with `make test` always returning true even when tests fail
 * Fix race condition that could cause failures due to astro downloading the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # astro changelog
 
-## 0.4.2 (UNRELEASED, 2018)
+## 0.5.0 (UNRELEASED, 2018)
 
 * Add Travis configuration, `make lint` and git precommit hook
 * Fix `--help` displaying "pflag: help requested" (#1)
@@ -9,6 +9,19 @@
 * Fix race condition that could cause failures due to astro downloading the
   same version of Terraform twice
 * Remove godep and move to Go modules (vgo)
+* Change configuration syntax for remapping CLI flags to Terraform module
+  variables
+
+**Breaking changes:**
+
+* Before, there was a `flag:` option underneath module variables in the project
+  configuration that allowed you to modify the name of the flag on the CLI that
+  would represent that variable (e.g.: "--environment" could be remapped to
+  "--env").
+
+  This has been removed and there is now a completely new section in the YAML
+  called "flags". See the "Remapping flags" section of the README for more
+  information.
 
 ## 0.4.1 (October 3, 2018)
 

--- a/README.md
+++ b/README.md
@@ -228,3 +228,18 @@ database-dev-us-east-1: OK No changes (9s)
 app-dev-us-east-1: OK No changes (10s)
 >
 ```
+
+#### Remapping CLI flags
+
+Astro is meant to be used every day by operators. If your Terraform variable names are long-winded to type at the CLI, you can remap them to something simpler. For example, instead of typing `--environment dev`, you may wish to shoren this to `--env dev`.
+
+You can specify a `flags:` block in your project configuration, like:
+
+```
+flags:
+  environment:
+    name: env
+    description: Environment to deploy to
+```
+
+This will remap the "environment" Terraform variable to `--env` on the astro command line. You can also specify a description that will show up in the `--help` text.

--- a/astro/cli/astro/cmd/cmd_test.go
+++ b/astro/cli/astro/cmd/cmd_test.go
@@ -56,6 +56,8 @@ var (
 	terraformVersionRepo *tvm.VersionRepo
 )
 
+const VERSION_LATEST = ""
+
 // compiles the astro binary and returns the path to it.
 func compileAstro() (string, error) {
 	f, err := ioutil.TempFile("", "")
@@ -108,6 +110,10 @@ type testResult struct {
 
 func runTest(t *testing.T, args []string, fixtureBasePath string, version string) *testResult {
 	fixturePath := fixtureBasePath
+
+	if version == VERSION_LATEST {
+		version = terraformVersionsToTest[len(terraformVersionsToTest)-1]
+	}
 
 	// Determine if this version has a version-specific fixture.
 	versionSpecificFixturePath := fmt.Sprintf("%s-%s", fixtureBasePath, version)
@@ -185,8 +191,8 @@ func getSessionDirs(sessionBaseDir string) ([]string, error) {
 }
 
 func TestHelpWorks(t *testing.T) {
-	result := runTest(t, []string{"--help"}, "", terraformVersionsToTest[len(terraformVersionsToTest)-1])
-	assert.Contains(t, "A tool for managing multiple Terraform modules", result.Stdout.String())
+	result := runTest(t, []string{"--help"}, "", VERSION_LATEST)
+	assert.Contains(t, "A tool for managing multiple Terraform modules", result.Stderr.String())
 	assert.NoError(t, result.Err)
 }
 

--- a/astro/cli/astro/cmd/cmd_test.go
+++ b/astro/cli/astro/cmd/cmd_test.go
@@ -184,6 +184,12 @@ func getSessionDirs(sessionBaseDir string) ([]string, error) {
 	return sessionDirs, nil
 }
 
+func TestHelpWorks(t *testing.T) {
+	result := runTest(t, []string{"--help"}, "", terraformVersionsToTest[len(terraformVersionsToTest)-1])
+	assert.Contains(t, "A tool for managing multiple Terraform modules", result.Stdout.String())
+	assert.NoError(t, result.Err)
+}
+
 func TestProjectApplyChangesSuccess(t *testing.T) {
 	for _, version := range terraformVersionsToTest {
 		t.Run(version, func(t *testing.T) {

--- a/astro/cli/astro/cmd/cmds.go
+++ b/astro/cli/astro/cmd/cmds.go
@@ -40,7 +40,7 @@ var applyCmd = &cobra.Command{
 			return err
 		}
 
-		vars := userVariables()
+		vars := flagsToUserVariables()
 
 		var moduleNames []string
 		if moduleNamesString != "" {
@@ -81,7 +81,7 @@ var planCmd = &cobra.Command{
 			return err
 		}
 
-		vars := userVariables()
+		vars := flagsToUserVariables()
 
 		var moduleNames []string
 		if moduleNamesString != "" {
@@ -111,25 +111,6 @@ var planCmd = &cobra.Command{
 
 		return nil
 	},
-}
-
-func userVariables() *astro.UserVariables {
-	values := make(map[string]string)
-	filters := make(map[string]bool)
-
-	for _, flag := range _flags {
-		if flag.Value != "" {
-			values[flag.Variable] = flag.Value
-			if flag.IsFilter {
-				filters[flag.Variable] = true
-			}
-		}
-	}
-
-	return &astro.UserVariables{
-		Values:  values,
-		Filters: filters,
-	}
 }
 
 func init() {

--- a/astro/cli/astro/cmd/cmds.go
+++ b/astro/cli/astro/cmd/cmds.go
@@ -57,7 +57,7 @@ var applyCmd = &cobra.Command{
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("error running Terraform: %v", err)
+			return fmt.Errorf("ERROR: %v", processError(err))
 		}
 
 		err = printExecStatus(status, results)
@@ -99,7 +99,7 @@ var planCmd = &cobra.Command{
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("error running Terraform: %v", err)
+			return fmt.Errorf("ERROR: %v", processError(err))
 		}
 
 		err = printExecStatus(status, results)
@@ -120,4 +120,16 @@ func init() {
 	planCmd.PersistentFlags().BoolVar(&detach, "detach", false, "disconnect remote state before planning")
 	planCmd.PersistentFlags().StringVar(&moduleNamesString, "modules", "", "list of modules to plan")
 	rootCmd.AddCommand(planCmd)
+}
+
+// processError interprets certain astro errors and embellishes them for
+// display on the CLI.
+func processError(err error) error {
+	switch e := err.(type) {
+	case astro.MissingRequiredVarsError:
+		// reverse map variables to CLI flags
+		return fmt.Errorf("missing required flags: %s", strings.Join(varsToFlagNames(e.MissingVars()), ", "))
+	default:
+		return err
+	}
 }

--- a/astro/cli/astro/cmd/fixtures/flags/merge_values.yaml
+++ b/astro/cli/astro/cmd/fixtures/flags/merge_values.yaml
@@ -1,7 +1,7 @@
 ---
 
 terraform:
-  version: 0.11.7
+  path: ../../../../../fixtures/mock-terraform/success
 
 modules:
   - name: foo_mgmt

--- a/astro/cli/astro/cmd/fixtures/flags/no_variables.yaml
+++ b/astro/cli/astro/cmd/fixtures/flags/no_variables.yaml
@@ -1,7 +1,7 @@
 ---
 
 terraform:
-  version: 0.11.7
+  path: ../../../../../fixtures/mock-terraform/success
 
 modules:
   - name: foo

--- a/astro/cli/astro/cmd/fixtures/flags/simple_variables.yaml
+++ b/astro/cli/astro/cmd/fixtures/flags/simple_variables.yaml
@@ -1,14 +1,18 @@
 ---
 
 terraform:
-  version: 0.11.7
+  path: ../../../../../fixtures/mock-terraform/success
+
+flags:
+  bar:
+    name: baz
+    description: Baz Description
 
 modules:
-  - name: foo
+  - name: fooModule
     path: .
     variables:
-      - name: no_flag
-      - name: with_flag
-        flag: flag_name
-      - name: with_values
+      - name: foo
+      - name: bar
+      - name: qux
         values: [dev, staging, prod]

--- a/astro/cli/astro/cmd/flags.go
+++ b/astro/cli/astro/cmd/flags.go
@@ -94,10 +94,6 @@ func addProjectFlagsToCommands(flags []*ProjectFlag, cmds ...*cobra.Command) {
 	for _, cmd := range cmds {
 		for _, flag := range flags {
 			flag.AddToFlagSet(cmd.Flags())
-
-			if len(flag.AllowedValues) > 0 {
-				cmd.MarkFlagRequired(flag.Name)
-			}
 		}
 
 		// Update help text for the command to include the user flags
@@ -130,7 +126,7 @@ func loadProjectFlagsFromConfig() ([]*ProjectFlag, error) {
 	// config doesn't fail with pflag.ErrHelp
 	args := []string{}
 	for _, arg := range os.Args {
-		if arg == "-h" || arg == "--help" {
+		if arg == "-h" || arg == "--help" || arg == "-help" {
 			continue
 		}
 		args = append(args, arg)
@@ -222,6 +218,22 @@ func flagsToFlagSet(flags []*ProjectFlag) *pflag.FlagSet {
 		flag.AddToFlagSet(flagSet)
 	}
 	return flagSet
+}
+
+// flagName returns the flag name, given a variable name.
+func flagName(variableName string) string {
+	if flag, ok := _conf.Flags[variableName]; ok {
+		return flag.Name
+	}
+	return variableName
+}
+
+// varsToFlagNames converts a list of variable names to CLI flags.
+func varsToFlagNames(variableNames []string) (flagNames []string) {
+	for _, v := range variableNames {
+		flagNames = append(flagNames, fmt.Sprintf("--%s", flagName(v)))
+	}
+	return flagNames
 }
 
 func uniqueStrings(strings []string) []string {

--- a/astro/cli/astro/cmd/flags.go
+++ b/astro/cli/astro/cmd/flags.go
@@ -18,31 +18,52 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
+	"github.com/uber/astro/astro"
 	"github.com/uber/astro/astro/conf"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
-// Flag is populated with the custom variables read from command line flags
-type Flag struct {
-	// Variable is the name of the Terraform variable set by the flag
-	Variable string
-	// Value is the value read from the command line, if present
+// Text that will be appended to the --help output for plan/apply, showing
+// user flags from the astro project config.
+const userHelpTemplate = `
+User flags:
+{{.ProjectFlagsHelp}}`
+
+// ProjectFlag is a CLI flag that represents a variable from the user's astro
+// project config file.
+type ProjectFlag struct {
+	// Name of the user flag at the command line
+	Name string
+	// Value is the string var the flag value will be put into
 	Value string
-	// Flag is the name of the command line flag used to set the variable
-	Flag string
-	// IsRequired is true when thie flag is mandatory
-	IsRequired bool
-	// IsFilter is true when thie flag acts as a filter for the list of modules
-	IsFilter bool
+	// Description is what shows up next to the flag in --help
+	Description string
+	// Variable is the name of the user variable from the user's astro project
+	// config that this flag maps to.
+	Variable string
 	// AllowedValues is the list of valid values for this flag
 	AllowedValues []string
 }
 
-// StringEnum implements pflag.Value interface, to check that the passed-in value is one of the strings in AllowedValues
+// AddToFlagSet adds the flag to the specified flag set.
+func (flag *ProjectFlag) AddToFlagSet(flags *pflag.FlagSet) {
+	if len(flag.AllowedValues) > 0 {
+		flags.Var(&StringEnum{Flag: flag}, flag.Name, flag.Description)
+	} else {
+		flags.StringVar(&flag.Value, flag.Name, "", flag.Description)
+	}
+}
+
+// StringEnum implements pflag.Value interface, to check that the passed-in
+// value is one of the strings in AllowedValues.
 type StringEnum struct {
-	Flag *Flag
+	Flag *ProjectFlag
 }
 
 // String returns the current value
@@ -50,7 +71,8 @@ func (s *StringEnum) String() string {
 	return s.Flag.Value
 }
 
-// Set checks that the passed-in value is only of the allowd values, and returns an error if it is not
+// Set checks that the passed-in value is only of the allowd values, and
+// returns an error if it is not
 func (s *StringEnum) Set(value string) error {
 	for _, allowedValue := range s.Flag.AllowedValues {
 		if allowedValue == value {
@@ -65,67 +87,141 @@ func (s *StringEnum) Type() string {
 	return "string"
 }
 
-// commandLineFlags returns a list of variables that can be set via command line
-func commandLineFlags(conf *conf.Project) ([]*Flag, error) {
-	var err error
-	flags := make([]*Flag, 0)
+// addProjectFlagsToCommands adds the user flags to the specified Cobra commands.
+func addProjectFlagsToCommands(flags []*ProjectFlag, cmds ...*cobra.Command) {
+	ProjectFlagSet := flagsToFlagSet(flags)
 
-	for _, moduleConf := range conf.Modules {
+	for _, cmd := range cmds {
+		for _, flag := range flags {
+			flag.AddToFlagSet(cmd.Flags())
+
+			if len(flag.AllowedValues) > 0 {
+				cmd.MarkFlagRequired(flag.Name)
+			}
+		}
+
+		// Update help text for the command to include the user flags
+		helpTmpl := cmd.HelpTemplate()
+		helpTmpl += "\nUser flags:\n"
+		helpTmpl += ProjectFlagSet.FlagUsages()
+
+		cmd.SetHelpTemplate(helpTmpl)
+
+		// Mark flag hidden so it doesn't appear in the normal help. We have to
+		// do this *after* calling FlagUsages above, otherwise the flags don't
+		// appear in the output.
+		for _, flag := range flags {
+			cmd.Flags().MarkHidden(flag.Name)
+		}
+	}
+}
+
+// Load the astro configuration file and read flags from the project config.
+func loadProjectFlagsFromConfig() ([]*ProjectFlag, error) {
+	findConfig := &cobra.Command{
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
+		},
+	}
+
+	// Strip the help options from os.Args so that the pre-loading of the
+	// config doesn't fail with pflag.ErrHelp
+	args := []string{}
+	for _, arg := range os.Args {
+		if arg == "-h" || arg == "--help" {
+			continue
+		}
+		args = append(args, arg)
+	}
+
+	// Do an early first parse of the config flag before the main command,
+	findConfig.PersistentFlags().StringVar(&userCfgFile, "config", "", "config file")
+	if err := findConfig.ParseFlags(args); err != nil {
+		return nil, err
+	}
+
+	config, err := currentConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return flagsFromConfig(config), nil
+}
+
+// flagsFromConfig reads the astro config and returns a list of ProjectFlags that
+// can be used to fill in astro variable values at runtime.
+func flagsFromConfig(config *conf.Project) (flags []*ProjectFlag) {
+	flagMap := map[string]*ProjectFlag{}
+
+	for _, moduleConf := range config.Modules {
 		for _, variableConf := range moduleConf.Variables {
-			if flags, err = addOrUpdateVariable(flags, variableConf); err != nil {
-				return nil, err
+			var flagName string
+			var flagConf conf.Flag
+
+			// Check for flag mapping in project configuration. This is a block
+			// in the configuration that allows users to remap variable names
+			// on the CLI and set a description for the --help message.
+			flagConf, flagConfExists := config.Flags[variableConf.Name]
+			if flagConfExists {
+				flagName = flagConf.Name
+			} else {
+				flagName = variableConf.Name
+			}
+
+			if flag, ok := flagMap[flagName]; ok {
+				// aggregate values from all variables in the config
+				flag.AllowedValues = uniqueStrings(append(flag.AllowedValues, variableConf.Values...))
+			} else {
+				flag := &ProjectFlag{
+					Name:          flagName,
+					Description:   flagConf.Description,
+					Variable:      variableConf.Name,
+					AllowedValues: variableConf.Values,
+				}
+
+				flagMap[variableConf.Name] = flag
 			}
 		}
 	}
 
-	for i := range flags {
-		flags[i].AllowedValues = uniqueStrings(flags[i].AllowedValues)
+	// return as list
+	for _, flag := range flagMap {
+		flags = append(flags, flag)
 	}
 
-	return flags, nil
+	return flags
 }
 
-func addOrUpdateVariable(flags []*Flag, variable conf.Variable) ([]*Flag, error) {
-	commandFlag := variable.CommandFlag()
-	found := false
-	for i := range flags {
-		if flags[i].Variable == variable.Name {
-			if err := checkVariableConsistency(flags[i], variable); err != nil {
-				return nil, err
-			}
-			flags[i].AllowedValues = append(flags[i].AllowedValues, variable.Values...)
-			found = true
-		}
-		if flags[i].Flag == commandFlag {
-			if flags[i].Variable != variable.Name {
-				return nil, fmt.Errorf("Flag '%s' is mapped to conflicting flags '%s' and '%s'", commandFlag, variable.Name, flags[i].Variable)
+// Create an astro.UserVariables suitable for passing into ExecutionParameters
+// from the user flags.
+func flagsToUserVariables() *astro.UserVariables {
+	values := make(map[string]string)
+	filters := make(map[string]bool)
+
+	for _, flag := range projectFlags {
+		if flag.Value != "" {
+			values[flag.Variable] = flag.Value
+			if len(flag.AllowedValues) > 0 {
+				filters[flag.Variable] = true
 			}
 		}
 	}
-	if !found {
-		flags = append(flags, &Flag{
-			Variable:      variable.Name,
-			Flag:          commandFlag,
-			IsRequired:    variable.IsRequired(),
-			IsFilter:      variable.IsFilter(),
-			AllowedValues: variable.Values,
-		})
+
+	return &astro.UserVariables{
+		Values:  values,
+		Filters: filters,
 	}
-	return flags, nil
 }
 
-func checkVariableConsistency(flag *Flag, variable conf.Variable) error {
-	commandFlag := variable.CommandFlag()
-	if flag.Flag != commandFlag {
-		return fmt.Errorf("variable '%s' is mapped to conflicting flags '%s' and '%s'", variable.Name, commandFlag, flag.Flag)
+// Converts a list of ProjectFlags to a pflag.FlagSet.
+func flagsToFlagSet(flags []*ProjectFlag) *pflag.FlagSet {
+	flagSet := pflag.NewFlagSet("ProjectFlags", pflag.ContinueOnError)
+	for _, flag := range flags {
+		flag.AddToFlagSet(flagSet)
 	}
-	if flag.IsRequired != variable.IsRequired() {
-		return fmt.Errorf("variable '%s' is inconsistently marked as required", variable.Name)
-	}
-	if flag.IsFilter != variable.IsFilter() {
-		return fmt.Errorf("variable '%s' is inconsistently used as filter", variable.Name)
-	}
-	return nil
+	return flagSet
 }
 
 func uniqueStrings(strings []string) []string {

--- a/astro/cli/astro/cmd/flags_test.go
+++ b/astro/cli/astro/cmd/flags_test.go
@@ -14,75 +14,72 @@
  * limitations under the License.
  */
 
-package cmd
+package cmd_test
 
 import (
 	"testing"
 
-	"github.com/uber/astro/astro"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestNoVariables(t *testing.T) {
-	c, err := astro.NewConfigFromFile("fixtures/flags/no_variables.yaml")
-	require.NoError(t, err)
-
-	flags, err := commandLineFlags(c)
-	require.NoError(t, err)
-
-	assert.Equal(t, []*Flag{}, flags)
+func TestHelpNoVariables(t *testing.T) {
+	result := runTest(t, []string{
+		"--config=fixtures/flags/no_variables.yaml",
+		"plan",
+		"--help",
+	}, "fixtures/flags", VERSION_LATEST)
+	assert.NotContains(t, result.Stderr.String(), "User flags:")
 }
 
-func TestSimpleVariables(t *testing.T) {
-	c, err := astro.NewConfigFromFile("fixtures/flags/simple_variables.yaml")
-	require.NoError(t, err)
+// func TestSimpleVariables(t *testing.T) {
+// 	c, err := astro.NewConfigFromFile("fixtures/flags/simple_variables.yaml")
+// 	require.NoError(t, err)
 
-	flags, err := commandLineFlags(c)
-	require.NoError(t, err)
+// 	flags, err := commandLineFlags(c)
+// 	require.NoError(t, err)
 
-	assert.Equal(t, []*Flag{
-		&Flag{
-			Variable:   "no_flag",
-			Flag:       "no_flag",
-			IsRequired: true,
-		},
-		&Flag{
-			Variable:   "with_flag",
-			Flag:       "flag_name",
-			IsRequired: true,
-		},
-		&Flag{
-			Variable: "with_values",
-			Flag:     "with_values",
-			IsFilter: true,
-			AllowedValues: []string{
-				"dev",
-				"prod",
-				"staging",
-			},
-		},
-	}, flags)
-}
+// 	assert.Equal(t, []*Flag{
+// 		&Flag{
+// 			Variable:   "no_flag",
+// 			Flag:       "no_flag",
+// 			IsRequired: true,
+// 		},
+// 		&Flag{
+// 			Variable:   "with_flag",
+// 			Flag:       "flag_name",
+// 			IsRequired: true,
+// 		},
+// 		&Flag{
+// 			Variable: "with_values",
+// 			Flag:     "with_values",
+// 			IsFilter: true,
+// 			AllowedValues: []string{
+// 				"dev",
+// 				"prod",
+// 				"staging",
+// 			},
+// 		},
+// 	}, flags)
+// }
 
-func TestMergeValues(t *testing.T) {
-	c, err := astro.NewConfigFromFile("fixtures/flags/merge_values.yaml")
-	require.NoError(t, err)
+// func TestMergeValues(t *testing.T) {
+// 	c, err := astro.NewConfigFromFile("fixtures/flags/merge_values.yaml")
+// 	require.NoError(t, err)
 
-	flags, err := commandLineFlags(c)
-	require.NoError(t, err)
+// 	flags, err := commandLineFlags(c)
+// 	require.NoError(t, err)
 
-	assert.Equal(t, []*Flag{
-		&Flag{
-			Variable: "environment",
-			Flag:     "environment",
-			IsFilter: true,
-			AllowedValues: []string{
-				"dev",
-				"mgmt",
-				"prod",
-				"staging",
-			},
-		},
-	}, flags)
-}
+// 	assert.Equal(t, []*Flag{
+// 		&Flag{
+// 			Variable: "environment",
+// 			Flag:     "environment",
+// 			IsFilter: true,
+// 			AllowedValues: []string{
+// 				"dev",
+// 				"mgmt",
+// 				"prod",
+// 				"staging",
+// 			},
+// 		},
+// 	}, flags)
+// }

--- a/astro/cli/astro/cmd/main.go
+++ b/astro/cli/astro/cmd/main.go
@@ -15,34 +15,26 @@
  */
 
 // Package cmd contains the source for the `astro` command line tool
-// that operators use to interact with the project. The layout of files
-// in this package is defined by Cobra, which is the library that powers
-// the CLI tool.
+// that operators use to interact with the project.
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 
-	"github.com/uber/astro/astro"
-	"github.com/uber/astro/astro/conf"
 	"github.com/uber/astro/astro/logger"
 
 	"github.com/spf13/cobra"
 )
 
+// CLI flags
 var (
-	userCfgFile string
-	trace       bool
-	userVars    map[string]string
-	verbose     bool
-
-	_flags   []*Flag
-	_conf    *conf.Project
-	_project *astro.Project
+	trace        bool
+	userCfgFile  string
+	projectFlags []*ProjectFlag
+	verbose      bool
 )
 
 var rootCmd = &cobra.Command{
@@ -50,15 +42,6 @@ var rootCmd = &cobra.Command{
 	Short:         "A tool for managing multiple Terraform modules.",
 	SilenceUsage:  true,
 	SilenceErrors: true,
-}
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() error {
-	// Best effort to parse flags from config files for now. TODO: we need to
-	// deal with errors here.
-	initUserFlagsFromConfig()
-	return rootCmd.Execute()
 }
 
 func init() {
@@ -77,90 +60,32 @@ func init() {
 	})
 }
 
-func initUserFlagsFromConfig() error {
-	findConfig := &cobra.Command{
-		SilenceUsage:  true,
-		SilenceErrors: true,
-		FParseErrWhitelist: cobra.FParseErrWhitelist{
-			UnknownFlags: true,
-		},
+// Main is the main entry point into the CLI program.
+func Main() (exitCode int) {
+	// Try to parse user flags from their astro config file. Reading the astro
+	// config could fail with an error, e.g. if there is no config file found,
+	// but this is not a hard failure. Save the error for later, so we can let
+	// the user know about the error in certain cases.
+	projectFlags, projectFlagsLoadErr := loadProjectFlagsFromConfig()
+	if projectFlags != nil && len(projectFlags) > 0 {
+		addProjectFlagsToCommands(projectFlags, applyCmd, planCmd)
 	}
 
-	findConfig.PersistentFlags().StringVar(&userCfgFile, "config", "", "config file")
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
 
-	if err := findConfig.ParseFlags(os.Args); err != nil {
-		return err
-	}
-	config, err := currentConfig()
-	if err != nil {
-		return err
-	}
-
-	_flags, err = commandLineFlags(config)
-	if err != nil {
-		return err
-	}
-	for _, flag := range _flags {
-		usage := fmt.Sprintf("Set \"%s\" Terraform variable", flag.Variable)
-		for _, command := range rootCmd.Commands() {
-			if len(flag.AllowedValues) > 0 {
-				command.Flags().Var(&StringEnum{Flag: flag}, flag.Flag, usage)
-			} else {
-				command.Flags().StringVar(&flag.Value, flag.Flag, "", usage)
-			}
-			if flag.IsRequired {
-				command.MarkFlagRequired(flag.Flag)
-			}
+		// If there was an error when parsing the user's project config file,
+		// then display a message to let them know in case they're wondering
+		// why their CLI flags are not working.
+		if projectFlagsLoadErr != nil && projectFlagsLoadErr != errCannotFindConfig {
+			fmt.Fprintf(os.Stderr, "\nThere was an error loading astro config:\n")
+			fmt.Fprintln(os.Stderr, projectFlagsLoadErr.Error())
 		}
+
+		// exit with error
+		return 1
 	}
 
-	return nil
-}
-
-// configFile returns the path of the project config file.
-func configFile() (string, error) {
-	// User provided config file path takes precedence
-	if userCfgFile != "" {
-		return userCfgFile, nil
-	}
-
-	// Try to find the config file
-	if path := firstExistingFilePath(configFileSearchPaths...); path != "" {
-		return path, nil
-	}
-
-	return "", errors.New("unable to find config file")
-}
-
-func currentConfig() (*conf.Project, error) {
-	if _conf != nil {
-		return _conf, nil
-	}
-
-	file, err := configFile()
-	if err != nil {
-		return nil, err
-	}
-	_conf, err = astro.NewConfigFromFile(file)
-
-	return _conf, err
-}
-
-func currentProject() (*astro.Project, error) {
-	if _project != nil {
-		return _project, nil
-	}
-
-	config, err := currentConfig()
-	if err != nil {
-		return nil, err
-	}
-	c, err := astro.NewProject(*config)
-	if err != nil {
-		return nil, fmt.Errorf("unable to load module configuration: %v", err)
-	}
-
-	_project = c
-
-	return _project, nil
+	// success
+	return 0
 }

--- a/astro/cli/astro/cmd/main.go
+++ b/astro/cli/astro/cmd/main.go
@@ -55,9 +55,9 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() error {
-	if err := initUserFlagsFromConfig(); err != nil {
-		return err
-	}
+	// Best effort to parse flags from config files for now. TODO: we need to
+	// deal with errors here.
+	initUserFlagsFromConfig()
 	return rootCmd.Execute()
 }
 

--- a/astro/cli/astro/main.go
+++ b/astro/cli/astro/main.go
@@ -17,15 +17,11 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/uber/astro/astro/cli/astro/cmd"
 )
 
 func main() {
-	if err := cmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
+	os.Exit(cmd.Main())
 }

--- a/astro/conf/astro.go
+++ b/astro/conf/astro.go
@@ -24,6 +24,10 @@ import (
 
 // Project represents the structure of the YAML configuration for astro.
 type Project struct {
+	// Flags is a mapping of module variable names to user flags, e.g. for on
+	// the CLI.
+	Flags map[string]Flag
+
 	// Hooks contains configuration of hooks that can be invoked at various
 	// stages of the CLI lifecycle.
 	Hooks Hooks

--- a/astro/conf/flags.go
+++ b/astro/conf/flags.go
@@ -16,19 +16,10 @@
 
 package conf
 
-// Variable represents a variable that can be passed into a
-// Terraform module.
-type Variable struct {
-	// Name is the name/key of the variable.
+// Flag is a user
+type Flag struct {
+	// Name of the flag that is visible to the user, e.g. on the CLI.
 	Name string
-	// Values is a list of possible values for the variable. A value of nil
-	// means the possible values are unbound.
-	Values []string
-}
-
-// IsFilter returns true if the command-line parameter acts as a filter
-//
-// The full behaviour is described in the README
-func (v *Variable) IsFilter() bool {
-	return len(v.Values) > 0
+	// Description is an optional description to show to the user.
+	Description string
 }

--- a/astro/templates.go
+++ b/astro/templates.go
@@ -19,12 +19,31 @@ package astro
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"strings"
 	"text/template"
 )
 
+var (
+	// matches "{fox}" in "the quick {fox}"
+	reVarPlaceholder = regexp.MustCompile(`\{(.*)\}`)
+)
+
+// extractMissingVarNames takes an input string like "foo {bar} {baz}" and
+// returns a list of the var names between {}, e.g. [bar, baz].
+func extractMissingVarNames(s string) (vars []string) {
+	matches := reVarPlaceholder.FindAllStringSubmatch(s, -1)
+	for _, match := range matches {
+		vars = append(vars, match[1])
+	}
+	return vars
+}
+
+// assertAllVarsReplaced asserts that all vars have been replaced in a string,
+// i.e. that there are no values like "{baz}" in the string. It returns an
+// error if there is.
 func assertAllVarsReplaced(s string) error {
-	if strings.ContainsAny(s, "{}") || strings.Contains(s, "<no value>") {
+	if strings.ContainsAny(s, "{}") {
 		return fmt.Errorf("not all vars replaced in string: %v", s)
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/spf13/cast v1.2.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/jwalterweatherman v0.0.0-20180109140146-7c0cea34c8ec // indirect
-	github.com/spf13/pflag v1.0.1 // indirect
+	github.com/spf13/pflag v1.0.1
 	github.com/spf13/viper v1.0.2
 	github.com/stretchr/testify v1.2.1
 	golang.org/x/sys v0.0.0-20171222143536-83801418e1b5 // indirect


### PR DESCRIPTION
This reworks the flags feature and refactors a lot of the code under the hood
to change the design and fix some issues.

* Fix the --help issue.

  Previously, --help didn't work at all and resulted in an error: `pflag: help
  requested` (see #1). This fixes that issue and also improves the printing of
  user flags in the --help text. User flags are now shown at the bottom,
  separate from builtin and global astro flags. E.g.:

  ```
  $ astro plan --help
  Generate execution plans for modules

  Usage:
    astro plan [flags] [-- [Terraform argument]...]

  Flags:
        --detach           disconnect remote state before planning
    -h, --help             help for plan
        --modules string   list of modules to plan

  Global Flags:
        --config string   config file
        --trace           trace output
    -v, --verbose         verbose output

  User flags:
        --env string      Environment to deploy
        --region string   Region to deploy
  $
  ```

* Previously, Terraform variable names were remapped to a different flag name
  by specifying the `flag:` option in the variable config, e.g.:

  ```
  - name: app
    path: core/app
    variables:
    - name: aws_region
      flag: region
  ```

  This meant if you had many modules defined with the same variable, you had to
  type out the mapping correctly every time or else you would get an error.

  The mapping configuration has now moved to its own block in the project
  config, which now looks like:

  ```
  flags:
    aws_region:
      name: region
      description: Region to deploy
  ```

  Users can now also specify a description that will appear in the --help text.

  Note that the flags section is completely optional, and be default astro will
  just expose the full variable name as the CLI flag.

* Refactoring

  The implementation of user/project flags did a lot of the error checking in
  the cli/astro package itself, however, we want to move in a direction where
  those checks occur in the core astro package. The CLI should be a thin
  wrapper around the core package.

  Because this results in a breaking change in the config, I'm going to bump
  this to 0.5.0.