### PR TITLE
Feat/support workspaces

### DIFF
--- a/astro/terraform/terraform_plan.go
+++ b/astro/terraform/terraform_plan.go
@@ -33,9 +33,6 @@ func (s *Session) Plan() (Result, error) {
 	args := []string{"plan", "-detailed-exitcode", fmt.Sprintf("-out=%s.plan", s.id)}
 
 	for key, val := range s.config.Variables {
-		logger.Trace.Println("key: %s", key)
-		logger.Trace.Println("value: %s", val)
-
 		if key != "workspace" {
 			args = append(args, "-var", fmt.Sprintf("%s=%s", key, val))
 		} else if key == "workspace" {
@@ -56,7 +53,6 @@ func (s *Session) Plan() (Result, error) {
 
 	args = append(args, s.config.TerraformParameters...)
 
-	logger.Trace.Println("args: %s", args)
 	process, err := s.terraformCommand(args, []int{0, 2})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Why
To support using terraform workspaces


```
variables:
  - name: workspace
     values: [default, integration]
```
This is compatible with the cartesian product they use to run all plans in parallel.

In the future this should be fixed so that workspaces becomes a separate key altogether and it integrates with creating a cartesian product using workspaces separately. Then each workspace should be passed to terraform_plan and terraform_apply which will checkout the workspace if it is set.