### PR TITLE
Add specific go-version to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/checkout@master
       - name: Set up Golang
         uses: actions/setup-go@master
+        with:
+            go-version: '1.12'
       - name: Do release
         uses: goreleaser/goreleaser-action@master
         with:


### PR DESCRIPTION
We've added github action config (#50), but it uses default [setup-go](https://github.com/actions/setup-go) action, which uses go version 1.10. We need later version of golang.