### PR TITLE
Add github_token variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,3 +20,5 @@ jobs:
         with:
           version: latest
           args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GITHUB_TOKEN is required for goreleaser to run.

According to the [docs](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret)
```
The GITHUB_TOKEN secret is a GitHub App installation token scoped to the repository
that contains your workflow. GitHub creates the GITHUB_TOKEN secret for you by
default, but you must include it in your workflow file in order for actions to use it.
```