### PR TITLE
Include tvm into the astro tarball

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,13 @@
 project_name: astro
-archive:
-  format_overrides:
-    - goos: darwin
-      format: zip
-  replacements:
-    amd64: 64-bit
-    386: 32-bit
-    darwin: macOS
+archives:
+  -
+    format_overrides:
+      - goos: darwin
+        format: zip
+    replacements:
+      amd64: 64-bit
+      386: 32-bit
+      darwin: macOS
 before:
   hooks:
     - go mod download
@@ -20,6 +21,13 @@ builds:
         goarch: 386
     ldflags:
       - -s -w -X github.com/uber/astro/astro/cli/astro/cmd.version={{.Version}} -X github.com/uber/astro/astro/cli/astro/cmd.commit={{.ShortCommit}} -X github.com/uber/astro/astro/cli/astro/cmd.date={{.Date}}
+  - binary: tvm
+    main: ./astro/tvm/cli/tvm/main.go
+    env:
+      - GO111MODULE=on
+    ignore:
+      - goos: darwin
+        goarch: 386
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,6 @@
 project_name: astro
 archives:
-  -
-    format_overrides:
+  - format_overrides:
       - goos: darwin
         format: zip
     replacements:
@@ -12,7 +11,8 @@ before:
   hooks:
     - go mod download
 builds:
-  - binary: astro
+  - id: astro
+    binary: astro
     main: ./astro/cli/astro/main.go
     env:
       - GO111MODULE=on
@@ -21,7 +21,8 @@ builds:
         goarch: 386
     ldflags:
       - -s -w -X github.com/uber/astro/astro/cli/astro/cmd.version={{.Version}} -X github.com/uber/astro/astro/cli/astro/cmd.commit={{.ShortCommit}} -X github.com/uber/astro/astro/cli/astro/cmd.date={{.Date}}
-  - binary: tvm
+  - id: tvm
+    binary: tvm
     main: ./astro/tvm/cli/tvm/main.go
     env:
       - GO111MODULE=on

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NOTE: Astro is currently experimental.
 
 **Installation**
 
-Install Astro using go get (Go >1.13 required):
+Install Astro using go get (Go >1.12 required):
 
 ```
 GO111MODULE=on go get github.com/uber/astro/astro/cli/astro

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NOTE: Astro is currently experimental.
 
 **Installation**
 
-Install Astro using go get (Go >1.12 required):
+Install Astro using go get (Go >1.13 required):
 
 ```
 GO111MODULE=on go get github.com/uber/astro/astro/cli/astro

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This will install a binary called `astro` in your `$GOPATH/bin`.
 
 Alternatively, you can download precompiled binaries from the [Github releases page](https://github.com/uber/astro/releases).
 
-Note that from version 0.6.0 tvm, a tool to download and install specific versions of Terraform for your platforms,
+Note that from version 0.6.0 `tvm`, a tool to download and install specific versions of Terraform for your platforms,
 is packaged together with astro.
 
 **Configuration**

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ This will install a binary called `astro` in your `$GOPATH/bin`.
 
 Alternatively, you can download precompiled binaries from the [Github releases page](https://github.com/uber/astro/releases).
 
+Note that from version 0.6.0 tvm, a tool to download and install specific versions of Terraform for your platforms,
+is packaged together with astro.
+
 **Configuration**
 
 Astro looks for a configuration file called `astro.yaml` in the current or parent directories. It is recommended to place this file in the same top-level directory of your project where the Terraform code exists (e.g. `terraform/astro.yaml`).

--- a/go.mod
+++ b/go.mod
@@ -34,3 +34,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.0.0-20171116090243-287cf08546ab // indirect
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -34,5 +34,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.0.0-20171116090243-287cf08546ab // indirect
 )
-
-go 1.13


### PR DESCRIPTION
This addresses #58.

Changes:
- archive -> archives as the latest version of goreleaser only recognize the plural one
- add tvm to the goreleaser builds (also add build id otherwise it defaults to project_name)
- add note to readme to say that tvm is included

Tested it by pushing tag and running
```
docker run --rm --privileged -v $PWD:/go/src/github.com/uber/astro -v /var/run/docker.sock:/var/run/docker.sock -w /go/src/github.com/uber/astro -e GITHUB_TOKEN=<> goreleaser/goreleaser  release --rm-dist
```
I've seen that goreleaser was successful and the tarballs with both astro and tvm were published to github.
