### PR TITLE
Add release target to Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.6.0 (January 15, 2020)
 
 ### Added
-* Add `tvm` binary to astro release
+* Add `tvm` binary to astro release (#61)
+* Add release target to Makefile as github actions are no longer available (#62)
 
 ## 0.5.0 (October 3, 2019)
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,20 @@ lint:
 		exit 1; \
 	fi;
 
+.PHONY: release
+release:
+	if [ ! -z "$(VERSION)" ]; then \
+	    git tag -a $(VERSION) -m "new version $(VERSION)"; \
+	    git push origin $(VERSION); \
+	fi;
+	docker pull golang:1.12-stretch
+	docker run --rm \
+		-v $(PWD):/go/astro \
+		-e GITHUB_TOKEN=$(GITHUB_TOKEN) golang:1.12-stretch \
+		bash -c \
+		"curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh && \
+		cd /go/astro && /go/bin/goreleaser release --rm-dist --skip-validate"
+
 .PHONY: test
 test:
 	go test -timeout 1m -coverprofile=.coverage.out ./... \


### PR DESCRIPTION
The approach that was used before to build release was involving using goreleaser docker container (see [Dockerfile](https://github.com/goreleaser/goreleaser/blob/master/Dockerfile)).
The problem with that was that Docker container uses Linux Alpine, which has the different version of libc. Some dependency of astro uses libc, so with the previous approach the binary won't start because `libc.musl-x86_64.so.1` is not available on Debian by default.

The new approach is to start golang docker container and make a release there.
